### PR TITLE
Add missing quotes around eventcommands

### DIFF
--- a/templates/object_eventcommand.conf.erb
+++ b/templates/object_eventcommand.conf.erb
@@ -15,7 +15,7 @@ object EventCommand "<%= @object_eventcommandname %>" {
   import "<%= @template_to_import -%>"
   <%- end -%>
   <%- if @command -%>
-  command = [ <% if @cmd_path -%><%= @cmd_path -%> + <% end -%><% @command.each_with_index do |cmd, i| %><%= cmd -%><%= ', ' if i < (@command.size - 1) %><% end %> ]
+  command = [ <% if @cmd_path -%><%= @cmd_path -%> + <% end -%><% @command.each_with_index do |cmd, i| %>"<%= cmd -%>"<%= ', ' if i < (@command.size - 1) %><% end %> ]
   <%- end -%>
   <%- if @arguments.any? -%>
 


### PR DESCRIPTION
This adds quotes around the "command" setting for eventcommands, which fixes icinga2 erroring out when trying to create an eventcommand object.