### PR TITLE
Remove Config Stamp

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,21 +3,10 @@
 # This class manages the Icinga 2 daemon.
 #
 class icinga2::service {
-  $config_stamp = '/var/lib/icinga2/.puppet-config-stamp'
-
-  Exec {
-    path => $::path,
-    user => 'root',
-  }
-
-  exec { 'icinga2 config stamp':
-    command     => "touch '${config_stamp}'",
-    refreshonly => true,
-  } ~>
-
   exec { 'icinga2 daemon config test':
     command => 'icinga2 daemon -C',
-    onlyif  => "test ! -e '${::icinga2::pid_file}' || test '${config_stamp}' -nt '${::icinga2::pid_file}'",
+    path    => $::path,
+    onlyif  => "test ! -e '${::icinga2::pid_file}'",
   } ~>
 
   service { 'icinga2':


### PR DESCRIPTION
Removed config_stamp because the file is always older than the pid_file, resulting in a restart of the service on every puppet run.

I'm honestly not sure what purpose the file serves since it should be properly restarted when the config class notifies the service class in init.pp at https://github.com/puppetlabs-operations/puppet-icinga2/blob/3c45933d4e7ddc080d23feb86e7a1e12c78d487c/manifests/init.pp#L64-#L65.